### PR TITLE
Reload after insert

### DIFF
--- a/scripts/controller.js
+++ b/scripts/controller.js
@@ -40,6 +40,7 @@ localportal.controller('InsertController', ['$scope', '$localStorage', '$locatio
                 "count": 0
             });
             $scope.newLinkBody = '';
+            window.location.reload();
         }
     }
 ]);


### PR DESCRIPTION
Fix #59 

リンク登録後にリロードするまで、時刻ソートがうまく動作しないことが分かったので、  
insertによるリンク登録時にはリロードをするようにした。  
生のjavascriptによる修正だからあまりいいやり方じゃないと思うが、とりあえず直した。